### PR TITLE
Removed unnecessary OR statement

### DIFF
--- a/workers/todos.js
+++ b/workers/todos.js
@@ -96,7 +96,7 @@ async function getTodos(request) {
   } else {
     data = JSON.parse(cache)
   }
-  const body = html(JSON.stringify(data.todos || []))
+  const body = html(JSON.stringify(data.todos))
   return new Response(body, {
     headers: { 'Content-Type': 'text/html' },
   })


### PR DESCRIPTION
Same reason as previous commit:

> Removed unneeded and buggy `||`. That OR would not have worked anyway, since `[]` in JS stringifies to an empty string so. the statement would have been `window.todos = ` (error, since next statement is a variable declaration). If it was really wanted, the proper way would have been to say `window.todos = ${todos || '[]'}` (note the quotes around []). There are already two different ways in which `todos` is defaulted to `[]`, so removed this dead, buggy code.
