### PR TITLE
Prevent `</script`, `<!--` and `<script` injection

### DIFF
--- a/workers/todos.js
+++ b/workers/todos.js
@@ -96,7 +96,7 @@ async function getTodos(request) {
   } else {
     data = JSON.parse(cache)
   }
-  const body = html(JSON.stringify(data.todos || []))
+  const body = html(JSON.stringify(data.todos || []).replace(/</g, "\\u003c"))
   return new Response(body, {
     headers: { 'Content-Type': 'text/html' },
   })


### PR DESCRIPTION
Currently, the JSON obtained from Cloudflare Workers KV is embedded into a `script` element without any escaping. This allows for XSS and DoS via suitable injections:

* If the JSON data contains `</script>`, the `script` element will be closed and the rest of the JSON data will be executed as JavaScript in the context of the app. This allows for stored XSS in the context of the app.
* If the JSON data contains `<!--<script>`, the `script` element will not be closed by the first (and only) `</script>` end tag and will thus not be executed. This renders the app non-functional.

See [the HTML spec](https://www.w3.org/TR/html53/semantics-scripting.html#restrictions-for-contents-of-script-elements) for the list of substring that should be escaped in script elements. 

Note that the JSON data is associated with an IP address and not a stable user identifier, so this is not Self XSS. But even if you should consider it so, please take into account that this is an official example for Cloudflare Workers KV that can easily be turned into a useful app (such as a comment section on a static webpage or a simple chat app) by only changing the cache key and the HTML template. Such an app would then directly be vulnerable to XSS and a single-request DoS attack. 

The proposed change deviates from the HTML spec above to produce valid JSON. The change should be propagated to [the developer documentation](https://developers.cloudflare.com/workers/tutorials/build-a-todo-list) and the [KV blog post](https://blog.cloudflare.com/building-a-to-do-list-with-workers-and-kv/), ideally together with a comment that explains why this escaping is necessary.